### PR TITLE
Add support for `cr --generate-release-notes`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Mark the created GitHub release as 'latest'
     required: false
     default: true
+  generate_release_notes:
+    description: Automatically generate the name and body for this release. See https://docs.github.com/en/rest/releases/releases
+    required: false
+    default: true
   packages_with_index:
     description: "Upload chart packages directly into publishing branch"
     required: false
@@ -88,6 +92,10 @@ runs:
 
         if [[ -n "${{ inputs.mark_as_latest }}" ]]; then
             args+=(--mark-as-latest "${{ inputs.mark_as_latest }}")
+        fi
+
+        if [[ -n "${{ inputs.generate_release_notes }}" ]]; then
+            args+=(--generate-release-notes "${{ inputs.generate_release_notes }}")
         fi
 
         if [[ -n "${{ inputs.packages_with_index }}" ]]; then

--- a/cr.sh
+++ b/cr.sh
@@ -36,6 +36,7 @@ Usage: $(basename "$0") <options>
     -s, --skip-packaging          Skip the packaging step (run your own packaging before using the releaser)
         --skip-existing           Skip package upload if release exists
     -l, --mark-as-latest          Mark the created GitHub release as 'latest' (default: true)
+        --generate-release-notes  Automatically generate the name and body for this release. See https://docs.github.com/en/rest/releases/releases (default: true)
         --packages-with-index     Upload chart packages directly into publishing branch
 EOF
 }

--- a/cr.sh
+++ b/cr.sh
@@ -51,6 +51,7 @@ main() {
   local skip_packaging=
   local skip_existing=
   local mark_as_latest=true
+  local generate_release_notes=true
   local packages_with_index=false
   local pages_branch=
 
@@ -198,6 +199,12 @@ parse_command_line() {
         shift
       fi
       ;;
+    --generate-release-notes)
+      if [[ -n "${2:-}" ]]; then
+        generate_release_notes="$2"
+        shift
+      fi
+      ;;
     -l | --mark-as-latest)
       if [[ -n "${2:-}" ]]; then
         mark_as_latest="$2"
@@ -318,6 +325,9 @@ release_charts() {
   fi
   if [[ "$mark_as_latest" = false ]]; then
     args+=(--make-release-latest=false)
+  fi
+  if [[ "$generate_release_notes" = true ]]; then
+    args+=(--generate-release-notes)
   fi
   if [[ -n "$pages_branch" ]]; then
     args+=(--pages-branch "$pages_branch")


### PR DESCRIPTION
The flag is for automatically generate the name and body for this release. See https://docs.github.com/en/rest/releases/releases (default: true)